### PR TITLE
Fix: header-title overlap

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -33,6 +33,8 @@ export default {
 	text-align: center;
 	color: $white;
 	background: $grey;
+	position: absolute;
+	top: 0;
 }
 
 </style>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -29,6 +29,7 @@
 	padding: 1rem 0;
 	display: flex;
 	position: fixed;
+	top: 0;
 
 	@media all and (min-width: $desktop) {
 		padding: 2rem 0;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -9,7 +9,7 @@ $yellow: #eec215;
 
 // Layout
 $tablet: 768px;
-$desktop: 1140px;
+$desktop: 1024px;
 
 .inner {
 	width: 95%;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -27,7 +27,7 @@
 	@media all and (min-width: $desktop) {
 		$headerHeight: 80px;
 		margin-top: $headerHeight;
-		min-height: calc(100vh - $headerHeight);
+		min-height: calc(100vh - #{$headerHeight});
 	}
 
 	&__title {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -24,6 +24,12 @@
 	justify-content: center;
 	min-height: 100vh;
 
+	@media all and (min-width: $desktop) {
+		$headerHeight: 80px;
+		margin-top: $headerHeight;
+		min-height: calc(100vh - $headerHeight);
+	}
+
 	&__title {
 		font-size: 2rem;
 


### PR DESCRIPTION
## Features
- homepage now accounts for height of header when in desktop mode

## Fixes
- desktop breakpoint reduced to 1024px
- `top: 0` added to AppHeader and App to ensure they are fixed to the top of the screen

## Before
![screen shot 2018-10-23 at 17 51 35](https://user-images.githubusercontent.com/2746248/47377104-4e5ace80-d6ec-11e8-93b0-4e82ea4a267e.png)

## After
![screen shot 2018-10-23 at 17 51 12](https://user-images.githubusercontent.com/2746248/47377081-426f0c80-d6ec-11e8-8e59-381218ce12b6.png)
