### PR TITLE
Fix: styles

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -86,7 +86,10 @@ export default {
 	&__title {
 		font-weight: bold;
 		margin-right: auto;
-		color: $yellow !important;
+
+		&:hover {
+			text-decoration: none;
+		}
 
 		@media all and (min-width: $tablet) {
 			font-size: 1.5rem;
@@ -94,7 +97,7 @@ export default {
 
 		&--light {
 			font-weight: normal;
-			color: $orange !important;
+			color: $orange;
 		}
 
 	}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -9,6 +9,7 @@ a {
 
 	&:hover {
 		color: $yellow;
+		text-decoration-color: $orange;
 	}
 
 	img {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -4,7 +4,7 @@
 
 /* Defaults */
 a {
-	color: $orange;
+	color: $yellow;
 	text-decoration: none;
 
 	&:hover {


### PR DESCRIPTION
## Features
- hovering a link now triggers an `orange` underline

## Fixes
- hovering a link no longer changes text colour from `yellow`
- remove text decoration when hovering the header title

## Before
<img width="1227" alt="screen shot 2018-10-26 at 15 41 54" src="https://user-images.githubusercontent.com/2746248/47573646-bea86080-d935-11e8-9b2f-6dd4aaee1577.png">

## After
<img width="1229" alt="screen shot 2018-10-26 at 15 41 23" src="https://user-images.githubusercontent.com/2746248/47573596-a20c2880-d935-11e8-8170-e38b10636b28.png">
